### PR TITLE
Update signals.py

### DIFF
--- a/users/signals.py
+++ b/users/signals.py
@@ -4,11 +4,13 @@ from django.dispatch import receiver
 
 from .models import Profile
 
-
 @receiver(post_save, sender=User)
 def create_profile(sender, instance, created, **kwargs):
     if created:
         Profile.objects.create(user=instance)
+    else:
+        user_id = instance.pk
+        Profile.objects.get_or_create(user_id=user_id)
 
 
 @receiver(post_save, sender=User)


### PR DESCRIPTION
Fix login, auto create profile of exits user:
If users have created it before, there will be an errors. Table user_profiles not exits user_id.
Exception Type:	RelatedObjectDoesNotExist
Exception Value:	User has no profile.